### PR TITLE
pxbabel.sty: replace CK base fonts

### DIFF
--- a/pxbabel.sty
+++ b/pxbabel.sty
@@ -436,61 +436,61 @@
 \ifpxbb@forcedeluxemulti
 
 % UniKS
-\pxDeclareBasicCJKShape{J21}{hmc}{l}{!utfkml--h}
-\pxDeclareBasicCJKShape{J21}{hmc}{m}{!utfkmr--h}
-\pxDeclareBasicCJKShape{J21}{hmc}{bx}{!utfkmb--h}
-\pxDeclareBasicCJKShape{J21}{hgt}{m}{!utfkgr--h}
-\pxDeclareBasicCJKShape{J21}{hgt}{bx}{!utfkgb--h}
-\pxDeclareBasicCJKShape{J21}{hgt}{eb}{!utfkge--h}
+\pxDeclareBasicCJKShape{J21}{hmc}{l}{!upnmkorminl-h}
+\pxDeclareBasicCJKShape{J21}{hmc}{m}{!upnmkorminr-h}
+\pxDeclareBasicCJKShape{J21}{hmc}{bx}{!upnmkorminb-h}
+\pxDeclareBasicCJKShape{J21}{hgt}{m}{!upnmkorgothr-h}
+\pxDeclareBasicCJKShape{J21}{hgt}{bx}{!upnmkorgothb-h}
+\pxDeclareBasicCJKShape{J21}{hgt}{eb}{!upnmkorgotheb-h}
 \pxDeclareKanjiFamily{J21}{mg}
-\pxDeclareBasicCJKShape{J21}{mg}{m}{!utfkmgr--h}
+\pxDeclareBasicCJKShape{J21}{mg}{m}{!upnmkormgothr-h}
 
-\pxDeclareBasicCJKShape{J31}{hmc}{l}{!utfkml--v}
-\pxDeclareBasicCJKShape{J31}{hmc}{m}{!utfkmr--v}
-\pxDeclareBasicCJKShape{J31}{hmc}{bx}{!utfkmb--v}
-\pxDeclareBasicCJKShape{J31}{hgt}{m}{!utfkgr--v}
-\pxDeclareBasicCJKShape{J31}{hgt}{bx}{!utfkgb--v}
-\pxDeclareBasicCJKShape{J31}{hgt}{eb}{!utfkge--v}
+\pxDeclareBasicCJKShape{J31}{hmc}{l}{!upnmkorminl-v}
+\pxDeclareBasicCJKShape{J31}{hmc}{m}{!upnmkorminr-v}
+\pxDeclareBasicCJKShape{J31}{hmc}{bx}{!upnmkorminb-v}
+\pxDeclareBasicCJKShape{J31}{hgt}{m}{!upnmkorgothr-v}
+\pxDeclareBasicCJKShape{J31}{hgt}{bx}{!upnmkorgothb-v}
+\pxDeclareBasicCJKShape{J31}{hgt}{eb}{!upnmkorgotheb-v}
 \pxDeclareKanjiFamily{J31}{mg}
-\pxDeclareBasicCJKShape{J31}{mg}{m}{!utfkmgr--v}
+\pxDeclareBasicCJKShape{J31}{mg}{m}{!upnmkormgothr-v}
 
 % UniGB
-\pxDeclareBasicCJKShape{J22}{hmc}{l}{!utfcml--h}
-\pxDeclareBasicCJKShape{J22}{hmc}{m}{!utfcmr--h}
-\pxDeclareBasicCJKShape{J22}{hmc}{bx}{!utfcmb--h}
-\pxDeclareBasicCJKShape{J22}{hgt}{m}{!utfcgr--h}
-\pxDeclareBasicCJKShape{J22}{hgt}{bx}{!utfcgb--h}
-\pxDeclareBasicCJKShape{J22}{hgt}{eb}{!utfcge--h}
+\pxDeclareBasicCJKShape{J22}{hmc}{l}{!upnmschminl-h}
+\pxDeclareBasicCJKShape{J22}{hmc}{m}{!upnmschminr-h}
+\pxDeclareBasicCJKShape{J22}{hmc}{bx}{!upnmschminb-h}
+\pxDeclareBasicCJKShape{J22}{hgt}{m}{!upnmschgothr-h}
+\pxDeclareBasicCJKShape{J22}{hgt}{bx}{!upnmschgothb-h}
+\pxDeclareBasicCJKShape{J22}{hgt}{eb}{!upnmschgotheb-h}
 \pxDeclareKanjiFamily{J22}{mg}
-\pxDeclareBasicCJKShape{J22}{mg}{m}{!utfcmgr--h}
+\pxDeclareBasicCJKShape{J22}{mg}{m}{!upnmschmgothr-h}
 
-\pxDeclareBasicCJKShape{J32}{hmc}{l}{!utfcml--v}
-\pxDeclareBasicCJKShape{J32}{hmc}{m}{!utfcmr--v}
-\pxDeclareBasicCJKShape{J32}{hmc}{bx}{!utfcmb--v}
-\pxDeclareBasicCJKShape{J32}{hgt}{m}{!utfcgr--v}
-\pxDeclareBasicCJKShape{J32}{hgt}{bx}{!utfcgb--v}
-\pxDeclareBasicCJKShape{J32}{hgt}{eb}{!utfcge--v}
+\pxDeclareBasicCJKShape{J32}{hmc}{l}{!upnmschminl-v}
+\pxDeclareBasicCJKShape{J32}{hmc}{m}{!upnmschminr-v}
+\pxDeclareBasicCJKShape{J32}{hmc}{bx}{!upnmschminb-v}
+\pxDeclareBasicCJKShape{J32}{hgt}{m}{!upnmschgothr-v}
+\pxDeclareBasicCJKShape{J32}{hgt}{bx}{!upnmschgothb-v}
+\pxDeclareBasicCJKShape{J32}{hgt}{eb}{!upnmschgotheb-v}
 \pxDeclareKanjiFamily{J32}{mg}
-\pxDeclareBasicCJKShape{J32}{mg}{m}{!utfcmgr--v}
+\pxDeclareBasicCJKShape{J32}{mg}{m}{!upnmschmgothr-v}
 
 % UniCNS
-\pxDeclareBasicCJKShape{J23}{hmc}{l}{!utftml--h}
-\pxDeclareBasicCJKShape{J23}{hmc}{m}{!utftmr--h}
-\pxDeclareBasicCJKShape{J23}{hmc}{bx}{!utftmb--h}
-\pxDeclareBasicCJKShape{J23}{hgt}{m}{!utftgr--h}
-\pxDeclareBasicCJKShape{J23}{hgt}{bx}{!utftgb--h}
-\pxDeclareBasicCJKShape{J23}{hgt}{eb}{!utftge--h}
+\pxDeclareBasicCJKShape{J23}{hmc}{l}{!upnmtchminl-h}
+\pxDeclareBasicCJKShape{J23}{hmc}{m}{!upnmtchminr-h}
+\pxDeclareBasicCJKShape{J23}{hmc}{bx}{!upnmtchminb-h}
+\pxDeclareBasicCJKShape{J23}{hgt}{m}{!upnmtchgothr-h}
+\pxDeclareBasicCJKShape{J23}{hgt}{bx}{!upnmtchgothb-h}
+\pxDeclareBasicCJKShape{J23}{hgt}{eb}{!upnmtchgotheb-h}
 \pxDeclareKanjiFamily{J23}{mg}
-\pxDeclareBasicCJKShape{J23}{mg}{m}{!utftmgr--h}
+\pxDeclareBasicCJKShape{J23}{mg}{m}{!upnmtchmgothr-h}
 
-\pxDeclareBasicCJKShape{J33}{hmc}{l}{!utftml--v}
-\pxDeclareBasicCJKShape{J33}{hmc}{m}{!utftmr--v}
-\pxDeclareBasicCJKShape{J33}{hmc}{bx}{!utftmb--v}
-\pxDeclareBasicCJKShape{J33}{hgt}{m}{!utftgr--v}
-\pxDeclareBasicCJKShape{J33}{hgt}{bx}{!utftgb--v}
-\pxDeclareBasicCJKShape{J33}{hgt}{eb}{!utftge--v}
+\pxDeclareBasicCJKShape{J33}{hmc}{l}{!upnmtchminl-v}
+\pxDeclareBasicCJKShape{J33}{hmc}{m}{!upnmtchminr-v}
+\pxDeclareBasicCJKShape{J33}{hmc}{bx}{!upnmtchminb-v}
+\pxDeclareBasicCJKShape{J33}{hgt}{m}{!upnmtchgothr-v}
+\pxDeclareBasicCJKShape{J33}{hgt}{bx}{!upnmtchgothb-v}
+\pxDeclareBasicCJKShape{J33}{hgt}{eb}{!upnmtchgotheb-v}
 \pxDeclareKanjiFamily{J33}{mg}
-\pxDeclareBasicCJKShape{J33}{mg}{m}{!utftmgr--v}
+\pxDeclareBasicCJKShape{J33}{mg}{m}{!upnmtchmgothr-v}
 
 \fi % pxbb@forcedeluxemulti
 


### PR DESCRIPTION
japanese-otf-uptex に中韓の本文用vf を追加しました。
https://github.com/t-tk/japanese-otf-uptex/issues/7
それを使うようにするためのpull requestを送ります。
ご検討のほどよろしくお願いします。